### PR TITLE
implementation of the clear form button on the new catalog registraton screen

### DIFF
--- a/frontend/src/containers/RegisterCatalog/BasicInformation.js
+++ b/frontend/src/containers/RegisterCatalog/BasicInformation.js
@@ -16,7 +16,7 @@ import { registerUserTable, updateUserTable } from "@/services/Metadata";
 
 export default function RegisterCatalogBasicInformation() {
 
-  const { catalog, setCatalog, setActiveStep } = useRegisterCatalog();
+  const { catalog, setCatalog, setActiveStep, emptyCatalog } = useRegisterCatalog();
 
   const mutation = useMutation({
     mutationFn: (data) => {
@@ -40,6 +40,10 @@ export default function RegisterCatalogBasicInformation() {
 
   const handleNext = () => {
     mutation.mutate(catalog)
+  }
+
+  const handleClear = () => {
+    setCatalog(emptyCatalog)
   }
 
   const onSelectTable = (value) => {
@@ -106,9 +110,7 @@ export default function RegisterCatalogBasicInformation() {
       {mutation.isError ? <Alert severity="error">
         <AlertTitle>{mutation.error.message}</AlertTitle>{mutation.error.response.data.error}</Alert> : null}
 
-      {!isValid && (<RegisterCatalogToolbar />)}
-      {isValid && (<RegisterCatalogToolbar onNext={handleNext} />)}
-
+      <RegisterCatalogToolbar onClear={handleClear} onNext={isValid ? handleNext : null} />
     </Box>
   );
 }

--- a/frontend/src/containers/RegisterCatalog/Toolbar.js
+++ b/frontend/src/containers/RegisterCatalog/Toolbar.js
@@ -7,7 +7,9 @@ export default function RegisterCatalogToolbar(props) {
   return (
     <Toolbar>
       {/* {!props.onPrev && <Button variant="contained" color="secondary" disabled>Prev</Button>} */}
-      {props.onPrev && <Button variant="contained" color="secondary" onClick={() => props.onPrev()} disabled={!props.onPrev} >Prev</Button>}
+      {props.onPrev && <Button variant="contained" color="secondary" onClick={() => props.onPrev()} disabled={!props.onPrev}>Prev</Button>}
+
+      {props.onClear && (<Button variant="contained" color="secondary" onClick={() => props.onClear()} sx={{ mr: 1 }}>Clear Form</Button>)}
       <Box sx={{ flexGrow: 1 }} />
 
       {!props.onSubmit && <Button variant="contained" color="primary" onClick={() => props.onNext()} disabled={!props.onNext}>Next</Button>}


### PR DESCRIPTION
#### Now on the registration screen there is a 'CLEAR FORM' button that when clicked clears the entire form, leaving it at the initial default.

![image](https://github.com/user-attachments/assets/4139495d-8909-401f-96bc-0a72c18bbd93)