### PR TITLE
feat: display Jupyter notebook in cluster detail page

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -59,6 +59,7 @@ target-version = "py312"
 extend-exclude = [
     "*/migrations/*.py",
     "staticfiles/*",
+    "target/metadata/notebooks/*.ipynb",
 ]
 
 [tool.ruff.lint]

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -17,6 +17,8 @@ psycopg2==2.9.10 # https://github.com/psycopg/psycopg2
 psycopg==3.2.3 # https://github.com/psycopg/psycopg
 nbconvert==7.17.1
 nbformat==5.10.4
+ipykernel==7.3.0
+matplotlib==3.11.0
 # Django
 # ------------------------------------------------------------------------------
 django==5.0.10  # pyup: < 5.1  # https://www.djangoproject.com/

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -15,6 +15,8 @@ pandas==2.2.3 # https://github.com/pandas-dev/pandas
 astropy>=6.1 # https://github.com/astropy/astropy
 psycopg2==2.9.10 # https://github.com/psycopg/psycopg2
 psycopg==3.2.3 # https://github.com/psycopg/psycopg
+nbconvert==7.17.1
+nbformat==5.10.4
 # Django
 # ------------------------------------------------------------------------------
 django==5.0.10  # pyup: < 5.1  # https://www.djangoproject.com/

--- a/backend/target/metadata/api/serializers.py
+++ b/backend/target/metadata/api/serializers.py
@@ -113,6 +113,7 @@ class SettingsSerializer(serializers.ModelSerializer[Settings]):
 class NestedTableSerializer(serializers.ModelSerializer[Table]):
     qs_columns = Table.objects.prefetch_related("columns")
     columns = ResumedColumnSerializer(qs_columns, many=True, read_only=True)
+    ucds = serializers.SerializerMethodField()
 
     qs_settings = Table.objects.prefetch_related("settings")
     settings = SettingsSerializer(qs_settings, many=False, read_only=True)
@@ -153,6 +154,7 @@ class NestedTableSerializer(serializers.ModelSerializer[Table]):
             "property_ra",
             "property_dec",
             "columns",
+            "ucds",
             "settings",
         ]
 
@@ -198,3 +200,7 @@ class NestedTableSerializer(serializers.ModelSerializer[Table]):
             if col:
                 return col.name
         return None
+
+    def get_ucds(self, obj):
+        columns = obj.columns.filter(ucd__isnull=False)
+        return {c.ucd: c.name for c in columns if c.ucd and c.name}

--- a/backend/target/metadata/api/views.py
+++ b/backend/target/metadata/api/views.py
@@ -1,6 +1,15 @@
+import base64
+import io
+import json
 import math
+import traceback as tb
+from contextlib import redirect_stderr
+from contextlib import redirect_stdout
+from pathlib import Path
 
+import nbformat
 from django.conf import settings
+from nbconvert import HTMLExporter
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -17,6 +26,78 @@ from .serializers import NestedTableSerializer
 from .serializers import SchemaSerializer
 from .serializers import SettingsSerializer
 from .serializers import TableSerializer
+
+
+def _execute_notebook_inprocess(nb):
+    """Execute notebook code cells in-process, capturing outputs."""
+    namespace = {}
+
+    # Ensure matplotlib uses a non-interactive backend before any import
+    exec("import matplotlib; matplotlib.use('Agg')", namespace)  # noqa: S102
+
+    for execution_count, cell in enumerate(nb.cells, start=1):
+        if cell.cell_type != "code":
+            continue
+
+        cell.outputs = []
+        cell.execution_count = execution_count
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+
+        try:
+            with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+                exec(cell.source, namespace)  # noqa: S102
+
+            # Capture any matplotlib figures produced by this cell
+            try:
+                import matplotlib.pyplot as plt
+
+                for fig_num in plt.get_fignums():
+                    fig = plt.figure(fig_num)
+                    buf = io.BytesIO()
+                    fig.savefig(buf, format="png", bbox_inches="tight")
+                    img_b64 = base64.b64encode(buf.getvalue()).decode()
+                    cell.outputs.append(
+                        nbformat.v4.new_output(
+                            output_type="display_data",
+                            data={"image/png": img_b64, "text/plain": "<Figure>"},
+                            metadata={},
+                        ),
+                    )
+                plt.close("all")
+            except ImportError:
+                pass
+
+        except Exception as exc:  # noqa: BLE001
+            cell.outputs.append(
+                nbformat.v4.new_output(
+                    output_type="error",
+                    ename=type(exc).__name__,
+                    evalue=str(exc),
+                    traceback=tb.format_exception(type(exc), exc, exc.__traceback__),
+                ),
+            )
+
+        stdout_val = stdout_buf.getvalue()
+        stderr_val = stderr_buf.getvalue()
+
+        if stdout_val:
+            cell.outputs.append(
+                nbformat.v4.new_output(
+                    output_type="stream",
+                    name="stdout",
+                    text=stdout_val,
+                ),
+            )
+        if stderr_val:
+            cell.outputs.append(
+                nbformat.v4.new_output(
+                    output_type="stream",
+                    name="stderr",
+                    text=stderr_val,
+                ),
+            )
 
 
 class TableRegistrationError(Exception):
@@ -463,38 +544,16 @@ class UserTableViewSet(ModelViewSet):
             return result
         return data
 
-    @action(detail=True, methods=["get"])
-    def data(self, request, pk=None):
-        # IMPORTANTE: Não pode ser utilizado o self.get_object()
-        # por que falha se um dos campos de filtro for "id"
-        # pk é a identificação que vem na url /{pk}/data/
-        # e não é afetada pelos filtros.
-        queryset = self.get_queryset()
-        table = queryset.prefetch_related("columns").get(pk=pk)
-
-        ucds = self.get_table_ucds(table)
-
-        # Total de linhas estimado da tabela.
-        count = table.nrows
-
-        # Pagination parameters
-        page = int(request.query_params.get("page", 1))
-        page_size = request.query_params.get(
-            "pageSize",
-            int(settings.REST_FRAMEWORK["PAGE_SIZE"]),
-        )
-
-        limit = int(page_size)
-        offset = (limit * page) - limit
-
-        # TODO: selecionar as colunas que serao utilizadas.
-
-        # Parse Filters
-        url_filters = self.parse_filters(request.query_params)
-
-        ordering = request.query_params.get("ordering", None)
-
-        db = MyDB(username=request.user.username)
+    def query_data(  # noqa: PLR0913
+        self,
+        table,
+        limit,
+        offset,
+        url_filters,
+        ordering,
+        ucds,
+    ):
+        db = MyDB(username=self.request.user.username)
         rows, count = db.query(
             tablename=table.name,
             limit=limit,
@@ -529,6 +588,47 @@ class UserTableViewSet(ModelViewSet):
                 bigint_columns.append(col.name)
 
         parsed_rows = self.sanitize_rows(rows, bigint_columns)
+        return parsed_rows, count
+
+    @action(detail=True, methods=["get"])
+    def data(self, request, pk=None):
+        # IMPORTANTE: Não pode ser utilizado o self.get_object()
+        # por que falha se um dos campos de filtro for "id"
+        # pk é a identificação que vem na url /{pk}/data/
+        # e não é afetada pelos filtros.
+        queryset = self.get_queryset()
+        table = queryset.prefetch_related("columns").get(pk=pk)
+
+        ucds = self.get_table_ucds(table)
+
+        # Total de linhas estimado da tabela.
+        count = table.nrows
+
+        # Pagination parameters
+        page = int(request.query_params.get("page", 1))
+        page_size = request.query_params.get(
+            "pageSize",
+            int(settings.REST_FRAMEWORK["PAGE_SIZE"]),
+        )
+
+        limit = int(page_size)
+        offset = (limit * page) - limit
+
+        # TODO: selecionar as colunas que serao utilizadas.
+
+        # Parse Filters
+        url_filters = self.parse_filters(request.query_params)
+
+        ordering = request.query_params.get("ordering", None)
+
+        parsed_rows, count = self.query_data(
+            table=table,
+            limit=limit,
+            offset=offset,
+            url_filters=url_filters,
+            ordering=ordering,
+            ucds=ucds,
+        )
 
         results = {
             "results": parsed_rows,
@@ -540,40 +640,72 @@ class UserTableViewSet(ModelViewSet):
 
     @action(detail=True, methods=["get"])
     def notebook(self, request, pk=None):
-        from pathlib import Path
-
-        import nbformat
-        from nbconvert import HTMLExporter
+        """Generate a notebook for the given table and record ID."""
 
         queryset = self.get_queryset()
-        table = queryset.prefetch_related("columns").get(pk=pk)
 
-        ucds = self.get_table_ucds(table)
+        main_table = queryset.prefetch_related("columns").get(pk=pk)
+
+        # Main table metadata ( cluster table metadata )
+        main_table_metadata = NestedTableSerializer(
+            main_table,
+            context={"request": request},
+        ).data
+
+        ucds = self.get_table_ucds(main_table)
         url_filters = self.parse_filters(request.query_params)
 
-        db = MyDB(username=request.user.username)
-        rows, _ = db.query(
-            tablename=table.name,
+        main_record, _ = self.query_data(
+            table=main_table,
             limit=1,
             offset=0,
             url_filters=url_filters,
+            ordering=None,
+            ucds=ucds,
         )
-
-        if not rows:
+        if len(main_record) != 1:
             return Response(
                 {"error": "Record not found"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        row = rows[0]
-        row.update(
-            {
-                "meta_id": str(row.get(ucds.get("meta.id;meta.main")) or ""),
-                "meta_ra": str(row.get(ucds.get("pos.eq.ra;meta.main")) or ""),
-                "meta_dec": str(row.get(ucds.get("pos.eq.dec;meta.main")) or ""),
-                "meta_radius_arcmin": str(row.get(ucds.get("phys.angSize;src")) or ""),
-            },
-        )
+        # Main record data ( cluster data for the given filters )
+        main_record = main_record[0]
+
+        # IF cluster
+        related_table_metadata = None
+        related_table_data = None
+
+        if main_table.catalog_type == Table.CATALOG_TYPE_CLUSTER:
+            if not main_table.related_table:
+                return Response(
+                    {"error": "Related table must be set for cluster catalogs."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            # Related table metadata ( members table metadata )
+            related_table_metadata = NestedTableSerializer(
+                main_table.related_table,
+                context={"request": self.request},
+            ).data
+
+            # Related table data ( members data for the given cluster )
+            cross_id_property = main_table_metadata.get("related_property_id")
+
+            related_filters = {}
+            related_filters[cross_id_property] = main_record[
+                (main_table_metadata.get("property_id"))
+            ]
+
+            # Related table data ( members data for the given cluster )
+            related_table_data, count = self.query_data(
+                table=main_table.related_table,
+                limit=None,
+                offset=0,
+                url_filters=related_filters,
+                ordering=None,
+                ucds=related_table_metadata.get("ucds"),
+            )
 
         template_path = (
             Path(__file__).parent.parent / "notebooks" / "cluster_detail_template.ipynb"
@@ -581,12 +713,23 @@ class UserTableViewSet(ModelViewSet):
         with template_path.open() as f:
             nb = nbformat.read(f, as_version=4)
 
+        def to_python_literal(value):
+            return json.dumps(value)
+
+        replacements = {
+            "main_table_metadata": to_python_literal(main_table_metadata),
+            "main_record": to_python_literal(main_record),
+            "related_table_metadata": to_python_literal(related_table_metadata),
+            "related_table_data": to_python_literal(related_table_data),
+        }
+
         for cell in nb.cells:
-            for key, value in row.items():
-                cell.source = cell.source.replace(
-                    f"{{{{{key}}}}}",
-                    str(value if value is not None else ""),
-                )
+            if cell.source.strip().startswith("# canvas-variables"):
+                for key, value in replacements.items():
+                    cell.source = cell.source.replace(f"{{{{{key}}}}}", value)
+                break
+
+        _execute_notebook_inprocess(nb)
 
         exporter = HTMLExporter()
         html, _ = exporter.from_notebook_node(nb)

--- a/backend/target/metadata/api/views.py
+++ b/backend/target/metadata/api/views.py
@@ -537,3 +537,58 @@ class UserTableViewSet(ModelViewSet):
         }
 
         return Response(results, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["get"])
+    def notebook(self, request, pk=None):
+        from pathlib import Path
+
+        import nbformat
+        from nbconvert import HTMLExporter
+
+        queryset = self.get_queryset()
+        table = queryset.prefetch_related("columns").get(pk=pk)
+
+        ucds = self.get_table_ucds(table)
+        url_filters = self.parse_filters(request.query_params)
+
+        db = MyDB(username=request.user.username)
+        rows, _ = db.query(
+            tablename=table.name,
+            limit=1,
+            offset=0,
+            url_filters=url_filters,
+        )
+
+        if not rows:
+            return Response(
+                {"error": "Record not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        row = rows[0]
+        row.update(
+            {
+                "meta_id": str(row.get(ucds.get("meta.id;meta.main")) or ""),
+                "meta_ra": str(row.get(ucds.get("pos.eq.ra;meta.main")) or ""),
+                "meta_dec": str(row.get(ucds.get("pos.eq.dec;meta.main")) or ""),
+                "meta_radius_arcmin": str(row.get(ucds.get("phys.angSize;src")) or ""),
+            },
+        )
+
+        template_path = (
+            Path(__file__).parent.parent / "notebooks" / "cluster_detail_template.ipynb"
+        )
+        with template_path.open() as f:
+            nb = nbformat.read(f, as_version=4)
+
+        for cell in nb.cells:
+            for key, value in row.items():
+                cell.source = cell.source.replace(
+                    f"{{{{{key}}}}}",
+                    str(value if value is not None else ""),
+                )
+
+        exporter = HTMLExporter()
+        html, _ = exporter.from_notebook_node(nb)
+
+        return Response({"html": html}, status=status.HTTP_200_OK)

--- a/backend/target/metadata/notebooks/cluster_detail_template.ipynb
+++ b/backend/target/metadata/notebooks/cluster_detail_template.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cluster Detail: {{meta_id}}\n",
+    "\n",
+    "| Property | Value |\n",
+    "|----------|-------|\n",
+    "| ID | {{meta_id}} |\n",
+    "| RA | {{meta_ra}} |\n",
+    "| Dec | {{meta_dec}} |\n",
+    "| Radius (arcmin) | {{meta_radius_arcmin}} |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Coordinates\n",
+    "\n",
+    "**Right Ascension:** {{meta_ra}}  \n",
+    "**Declination:** {{meta_dec}}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Properties\n",
+    "\n",
+    "Use this section to add catalog-specific analysis or visualizations."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/backend/target/metadata/notebooks/cluster_detail_template.ipynb
+++ b/backend/target/metadata/notebooks/cluster_detail_template.ipynb
@@ -1,36 +1,97 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd5c792f",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# Cluster Detail: {{meta_id}}\n",
-    "\n",
-    "| Property | Value |\n",
-    "|----------|-------|\n",
-    "| ID | {{meta_id}} |\n",
-    "| RA | {{meta_ra}} |\n",
-    "| Dec | {{meta_dec}} |\n",
-    "| Radius (arcmin) | {{meta_radius_arcmin}} |"
+    "import json"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "canvas-variables",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Coordinates\n",
-    "\n",
-    "**Right Ascension:** {{meta_ra}}  \n",
-    "**Declination:** {{meta_dec}}"
+    "# canvas-variables\n",
+    "main_table_metadata = json.loads(\"\"\"{{main_table_metadata}}\"\"\")\n",
+    "main_record = json.loads(\"\"\"{{main_record}}\"\"\")\n",
+    "related_table_metadata = json.loads(\"\"\"{{related_table_metadata}}\"\"\")\n",
+    "related_table_data = json.loads(\"\"\"{{related_table_data}}\"\"\")"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "957b73e4",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Additional Properties\n",
+    "# Check if notebook is running in a Jupyter environment\n",
+    "print(\"Main table metadata:\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb394b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check if the variables are correctly loaded\n",
+    "print(f\"Name: {main_table_metadata['title']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88efb91a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check main table metadata\n",
+    "print(json.dumps(main_table_metadata))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8fdebd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check main record\n",
+    "print(json.dumps(main_record, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0075eeaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check related table metadata\n",
+    "print(f\"Related table name: {related_table_metadata['title']}\")\n",
+    "print(json.dumps(related_table_metadata))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdfcbaba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check related table data\n",
+    "print(f\"Related table data: {len(related_table_data)}\")\n",
     "\n",
-    "Use this section to add catalog-specific analysis or visualizations."
+    "for row in related_table_data:\n",
+    "    print(json.dumps(row))"
    ]
   }
  ],

--- a/frontend/src/app/(authenticated)/catalog/[schema]/[table]/cluster_detail/[id]/page.js
+++ b/frontend/src/app/(authenticated)/catalog/[schema]/[table]/cluster_detail/[id]/page.js
@@ -68,7 +68,6 @@ export default function SingleClusterDetail({ params }) {
   return (
     <Box sx={{
       width: '100%',
-      height: '100%',
       display: 'flex',
       flexDirection: 'column',
     }}

--- a/frontend/src/containers/ClusterDetail/index.js
+++ b/frontend/src/containers/ClusterDetail/index.js
@@ -273,7 +273,7 @@ export default function ClusterDetailContainer({ catalog, record }) {
         </Paper>
       )}
       {/* Spacer */}
-      <Box mt={4} />
+      <Box mt={6} />
     </Box>
   );
 

--- a/frontend/src/containers/ClusterDetail/index.js
+++ b/frontend/src/containers/ClusterDetail/index.js
@@ -127,11 +127,17 @@ export default function ClusterDetailContainer({ catalog, record }) {
     if (!notebookHtml) setIframeHeight(0);
   }, [notebookHtml]);
 
-  const handleIframeLoad = () => {
+  const measureIframeHeight = () => {
     const doc = iframeRef.current?.contentDocument;
     if (doc) {
       setIframeHeight(doc.documentElement.scrollHeight);
     }
+  };
+
+  const handleIframeLoad = () => {
+    measureIframeHeight();
+    // Re-measure after a short delay so late-painted content (images, CSS) is included.
+    setTimeout(measureIframeHeight, 500);
   };
 
 
@@ -150,104 +156,104 @@ export default function ClusterDetailContainer({ catalog, record }) {
   }, [selectedMember]);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', gap: 2 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }} mb={4}>
       <Grid container spacing={2}>
-      <Grid size={{ md: 6 }} sx={{ height: 600 }}>
-        <Paper elevation={3} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-          <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
-            <Tab label="Members" />
-            <Tab label="Properties" />
-          </Tabs>
+        <Grid size={{ md: 6 }} sx={{ height: 600 }}>
+          <Paper elevation={3} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+            <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
+              <Tab label="Members" />
+              <Tab label="Properties" />
+            </Tabs>
 
-          <TabPanel value={activeTab} index={0}>
-            {isLoadingMembersCatalog && (
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 100 }}>
-                <CircularProgress />
-              </Box>
-            )}
-            {(!isLoadingMembersCatalog && membersCatalog !== undefined) && (
-              <Box sx={{ width: '100%', height: '100%' }}>
-                <MembersDataGrid
-                  type={membersCatalog.catalog_type}
-                  tableId={membersCatalog.id}
-                  schema={membersCatalog.schema}
-                  table={membersCatalog.table}
-                  tableColumns={membersCatalog.columns}
-                  property_cross_id={catalog.related_property_id}
-                  clusterId={record?.meta_id}
-                  onChangeSelection={onChangeSelection}
-                />
-              </Box>
-            )}
-          </TabPanel>
+            <TabPanel value={activeTab} index={0}>
+              {isLoadingMembersCatalog && (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 100 }}>
+                  <CircularProgress />
+                </Box>
+              )}
+              {(!isLoadingMembersCatalog && membersCatalog !== undefined) && (
+                <Box sx={{ width: '100%', height: '100%' }}>
+                  <MembersDataGrid
+                    type={membersCatalog.catalog_type}
+                    tableId={membersCatalog.id}
+                    schema={membersCatalog.schema}
+                    table={membersCatalog.table}
+                    tableColumns={membersCatalog.columns}
+                    property_cross_id={catalog.related_property_id}
+                    clusterId={record?.meta_id}
+                    onChangeSelection={onChangeSelection}
+                  />
+                </Box>
+              )}
+            </TabPanel>
 
-          <TabPanel value={activeTab} index={1}>
-            <TargetProperties record={record} />
-          </TabPanel>
-        </Paper>
-      </Grid>
+            <TabPanel value={activeTab} index={1}>
+              <TargetProperties record={record} />
+            </TabPanel>
+          </Paper>
+        </Grid>
 
-      <Grid size={{ md: 6 }} sx={{ height: 600 }}>
-        <Paper
-          elevation={3}
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            position: 'relative',
-            height: '100%',
-          }}
-        >
-          <Box sx={{ flex: 1, position: 'relative' }}>
-            <AladinViewer />
-          </Box>
-
-          <Toolbar
-            orientation="vertical"
+        <Grid size={{ md: 6 }} sx={{ height: 600 }}>
+          <Paper
+            elevation={3}
             sx={{
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'flex-start',
-              width: 64,
-              borderLeft: (theme) => `1px solid ${theme.palette.divider}`,
-              backgroundColor: (theme) => theme.palette.background.paper,
-              paddingY: 1,
-              gap: 1,
+              display: 'flex',
+              flexDirection: 'row',
+              position: 'relative',
+              height: '100%',
             }}
           >
-            <Tooltip title="Center on target">
-              <IconButton aria-label="center" disabled={!record} onClick={centerOnTarget}>
-                <MyLocationIcon />
-              </IconButton>
-            </Tooltip>
+            <Box sx={{ flex: 1, position: 'relative' }}>
+              <AladinViewer />
+            </Box>
 
-            <Tooltip title="Show/Hide Cluster Radius">
-              <IconButton aria-label="show-hide-marker" disabled={!record} onClick={toggleMarkerVisibility}>
-                <PanoramaFishEyeIcon />
-              </IconButton>
-            </Tooltip>
+            <Toolbar
+              orientation="vertical"
+              sx={{
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+                width: 64,
+                borderLeft: (theme) => `1px solid ${theme.palette.divider}`,
+                backgroundColor: (theme) => theme.palette.background.paper,
+                paddingY: 1,
+                gap: 1,
+              }}
+            >
+              <Tooltip title="Center on target">
+                <IconButton aria-label="center" disabled={!record} onClick={centerOnTarget}>
+                  <MyLocationIcon />
+                </IconButton>
+              </Tooltip>
 
-            <Tooltip title="Show/Hide members">
-              <IconButton
-                aria-label="show-hide-members"
-                disabled={!record}
-                onClick={toggleCatalogVisibility.bind(this, 'Members')}
-              >
-                {isLoadingMembers ? <CircularProgress size={24} /> : <ScatterPlotIcon />}
-              </IconButton>
-            </Tooltip>
+              <Tooltip title="Show/Hide Cluster Radius">
+                <IconButton aria-label="show-hide-marker" disabled={!record} onClick={toggleMarkerVisibility}>
+                  <PanoramaFishEyeIcon />
+                </IconButton>
+              </Tooltip>
 
-            <Tooltip title="Take snapshot">
-              <IconButton aria-label="take-snapshot" disabled={!record} onClick={takeSnapshot}>
-                <CameraAltIcon />
-              </IconButton>
-            </Tooltip>
-          </Toolbar>
-        </Paper>
-      </Grid>
+              <Tooltip title="Show/Hide members">
+                <IconButton
+                  aria-label="show-hide-members"
+                  disabled={!record}
+                  onClick={toggleCatalogVisibility.bind(this, 'Members')}
+                >
+                  {isLoadingMembers ? <CircularProgress size={24} /> : <ScatterPlotIcon />}
+                </IconButton>
+              </Tooltip>
+
+              <Tooltip title="Take snapshot">
+                <IconButton aria-label="take-snapshot" disabled={!record} onClick={takeSnapshot}>
+                  <CameraAltIcon />
+                </IconButton>
+              </Tooltip>
+            </Toolbar>
+          </Paper>
+        </Grid>
 
       </Grid>
       {(isLoadingNotebook || (notebookHtml && !iframeHeight)) && (
-        <Skeleton variant="rectangular" sx={{ flex: 1, borderRadius: 1 }} />
+        <Skeleton variant="rectangular" height={500} sx={{ borderRadius: 1 }} />
       )}
       {notebookHtml && (
         // Paper permanece no DOM com height:0 enquanto o iframe mede seu conteúdo.
@@ -266,6 +272,8 @@ export default function ClusterDetailContainer({ catalog, record }) {
           />
         </Paper>
       )}
+      {/* Spacer */}
+      <Box mt={4} />
     </Box>
   );
 

--- a/frontend/src/containers/ClusterDetail/index.js
+++ b/frontend/src/containers/ClusterDetail/index.js
@@ -4,13 +4,14 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid2';
 import { useEffect } from 'react'
 import CircularProgress from '@mui/material/CircularProgress';
+import Skeleton from '@mui/material/Skeleton';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import TargetProperties from "@/components/TargetProperties";
 import MembersDataGrid from "@/components/MembersDataGrid";
 import { useAladinContext } from '@/components/Aladin/AladinContext';
 import AladinViewer from '@/components/Aladin/AladinViewer';
-import { getClusterMembers, getMetadataById } from '@/services/Metadata';
+import { getClusterMembers, getMetadataById, getNotebookHtml } from '@/services/Metadata';
 import { useQuery } from '@tanstack/react-query'
 
 import Stack from '@mui/material/Stack';
@@ -36,6 +37,8 @@ export default function ClusterDetailContainer({ catalog, record }) {
 
   const [selectedMember, setSelectedMember] = React.useState(undefined);
   const [activeTab, setActiveTab] = React.useState(0);
+  const [iframeHeight, setIframeHeight] = React.useState(0);
+  const iframeRef = React.useRef(null);
 
   useEffect(() => {
     // Quando o catalogo tem uma imagem/survey default
@@ -107,6 +110,29 @@ export default function ClusterDetailContainer({ catalog, record }) {
       addCatalog('Members', members)
     }
   }, [members]);
+
+  const { isLoading: isLoadingNotebook, data: notebookHtml } = useQuery({
+    queryKey: ['notebookHtml', catalog.id, record?.meta_id],
+    queryFn: () => getNotebookHtml({
+      tableId: catalog.id,
+      propertyId: catalog.property_id,
+      recordId: record.meta_id,
+    }),
+    select: (data) => data?.data?.html,
+    enabled: !!record?.meta_id && !!catalog?.property_id,
+    staleTime: 5 * 60000,
+  });
+
+  useEffect(() => {
+    if (!notebookHtml) setIframeHeight(0);
+  }, [notebookHtml]);
+
+  const handleIframeLoad = () => {
+    const doc = iframeRef.current?.contentDocument;
+    if (doc) {
+      setIframeHeight(doc.documentElement.scrollHeight);
+    }
+  };
 
 
   const onChangeSelection = (selectedRows) => {
@@ -220,7 +246,26 @@ export default function ClusterDetailContainer({ catalog, record }) {
       </Grid>
 
       </Grid>
-      <Paper elevation={3} sx={{ flex: 1 }} />
+      {(isLoadingNotebook || (notebookHtml && !iframeHeight)) && (
+        <Skeleton variant="rectangular" sx={{ flex: 1, borderRadius: 1 }} />
+      )}
+      {notebookHtml && (
+        // Paper permanece no DOM com height:0 enquanto o iframe mede seu conteúdo.
+        // overflow:hidden esconde visualmente mas mantém o layout computado,
+        // permitindo que onLoad dispare e scrollHeight seja lido corretamente.
+        <Paper
+          elevation={iframeHeight ? 3 : 0}
+          sx={{ width: '100%', height: iframeHeight || 0, overflow: 'hidden' }}
+        >
+          <iframe
+            ref={iframeRef}
+            srcDoc={notebookHtml}
+            onLoad={handleIframeLoad}
+            style={{ width: '100%', height: iframeHeight || 1, border: 'none', display: 'block' }}
+            title="Cluster Notebook"
+          />
+        </Paper>
+      )}
     </Box>
   );
 

--- a/frontend/src/services/Metadata.js
+++ b/frontend/src/services/Metadata.js
@@ -56,7 +56,7 @@ export const getTableData = (params) => {
 }
 
 export const getMembersTableData = (params) => {
-    // Igual a tabledata mais adiciona o filtro por cluster id. 
+    // Igual a tabledata mais adiciona o filtro por cluster id.
     // Permiter utilizar todas as opções de paginação, ordenação e filtro.
     const queryParams = parseQueryOptions(params)
     queryParams.params[params.property_cross_id] = params.clusterId
@@ -83,6 +83,12 @@ export const getClusterMembers = ({ tableId, property_cross_id, value }) => {
 
 
 
+export const getNotebookHtml = ({ tableId, propertyId, recordId }) => {
+    return api.get(`metadata/user_tables/${tableId}/notebook/`, {
+        params: { [propertyId]: recordId }
+    })
+}
+
 export const createTableSettings = (data) => {
     return api.post("metadata/settings/", data);
 }
@@ -90,4 +96,3 @@ export const createTableSettings = (data) => {
 export const updateTableSettings = (data) => {
     return api.patch(`metadata/settings/${data.id}/`, data);
 }
-


### PR DESCRIPTION
Adds a pre-rendered Jupyter notebook panel at the bottom of the Cluster Detail page. The notebook is executed server-side with the cluster's data injected as variables and returned as HTML, displayed in an iframe below the Members/Aladin section.

## Backend:

- New endpoint GET /api/metadata/user_tables/{id}/notebook/ that fetches a single cluster row, injects the record, table metadata, and (for cluster catalogs) the related members data into a dedicated # canvas-variables notebook cell, executes it in-process, and returns the rendered HTML via nbconvert
- query_data helper maps UCD-based virtual fields (meta_id, meta_ra, meta_dec, meta_radius_arcmin) onto each fetched row
- ucds field added to NestedTableSerializer exposing a UCD→column-name map for notebooks to consume
- Added dependencies: nbconvert, nbformat, ipykernel, matplotlib

## Frontend:

- getNotebookHtml service calls the new endpoint using catalog.property_id as the filter key and record.meta_id as the value
- ClusterDetail fetches the notebook HTML with useQuery and renders it in an iframe via srcDoc
- A Skeleton fills the space while loading; on onLoad the iframe's scrollHeight is measured (with a 500ms re-measure to capture late-painted images/CSS) and the Paper expands to the exact content height
- Layout fixes: removed height: 100% constraints that capped the page at viewport height, preventing the notebook content from being scrollable in full

Test plan
 Open a cluster detail page for a catalog with a notebook template configured
 Verify the Skeleton appears while the notebook loads
 Verify the notebook renders fully below the Members/Aladin section
 Scroll to the bottom and confirm the full notebook content is visible with spacing at the end
 Verify the Members tab, Properties tab, and Aladin viewer still work correctly
 Open a cluster from a catalog without a notebook — confirm no iframe or skeleton appears